### PR TITLE
feat: added stack block, transaction and contract schema

### DIFF
--- a/schemas/stack_block.avsc
+++ b/schemas/stack_block.avsc
@@ -1,0 +1,102 @@
+{
+    "type": "record",
+    "name": "BlockRecord",
+    "fields": [
+        {
+            "name": "canonical",
+            "type": "boolean"
+        },
+        {
+            "name": "height",
+            "type": "int"
+        },
+        {
+            "name": "hash",
+            "type": "string"
+        },
+        {
+            "name": "index_block_hash",
+            "type": "string"
+        },
+        {
+            "name": "parent_block_hash",
+            "type": "string"
+        },
+        {
+            "name": "burn_block_time",
+            "type": "long"
+        },
+        {
+            "name": "burn_block_time_iso",
+            "type": "string"
+        },
+        {
+            "name": "burn_block_hash",
+            "type": "string"
+        },
+        {
+            "name": "burn_block_height",
+            "type": "long"
+        },
+        {
+            "name": "miner_txid",
+            "type": "string"
+        },
+        {
+            "name": "parent_microblock_hash",
+            "type": "string"
+        },
+        {
+            "name": "parent_microblock_sequence",
+            "type": "int"
+        },
+        {
+            "name": "txs",
+            "type": {
+                "type": "array",
+                "items": "string"
+            }
+        },
+        {
+            "name": "microblocks_accepted",
+            "type": {
+                "type": "array",
+                "items": "string"
+            }
+        },
+        {
+            "name": "microblocks_streamed",
+            "type": {
+                "type": "array",
+                "items": "string"
+            }
+        },
+        {
+            "name": "execution_cost_read_count",
+            "type": "int"
+        },
+        {
+            "name": "execution_cost_read_length",
+            "type": "int"
+        },
+        {
+            "name": "execution_cost_runtime",
+            "type": "int"
+        },
+        {
+            "name": "execution_cost_write_count",
+            "type": "int"
+        },
+        {
+            "name": "execution_cost_write_length",
+            "type": "int"
+        },
+        {
+            "name": "microblock_tx_count",
+            "type": {
+                "type": "map",
+                "values": "int"
+            }
+        }
+    ]
+}

--- a/schemas/stack_block.avsc
+++ b/schemas/stack_block.avsc
@@ -8,7 +8,7 @@
         },
         {
             "name": "height",
-            "type": "int"
+            "type": "long"
         },
         {
             "name": "hash",
@@ -48,7 +48,7 @@
         },
         {
             "name": "parent_microblock_sequence",
-            "type": "int"
+            "type": "long"
         },
         {
             "name": "txs",
@@ -73,29 +73,29 @@
         },
         {
             "name": "execution_cost_read_count",
-            "type": "int"
+            "type": "long"
         },
         {
             "name": "execution_cost_read_length",
-            "type": "int"
+            "type": "long"
         },
         {
             "name": "execution_cost_runtime",
-            "type": "int"
+            "type": "long"
         },
         {
             "name": "execution_cost_write_count",
-            "type": "int"
+            "type": "long"
         },
         {
             "name": "execution_cost_write_length",
-            "type": "int"
+            "type": "long"
         },
         {
             "name": "microblock_tx_count",
             "type": {
                 "type": "map",
-                "values": "int"
+                "values": "long"
             }
         }
     ]

--- a/schemas/stack_contract.avsc
+++ b/schemas/stack_contract.avsc
@@ -1,0 +1,37 @@
+{
+    "type": "record",
+    "name": "Contract",
+    "fields": [
+        {
+            "name": "tx_id",
+            "type": "string"
+        },
+        {
+            "name": "canonical",
+            "type": "boolean"
+        },
+        {
+            "name": "contract_id",
+            "type": "string"
+        },
+        {
+            "name": "block_height",
+            "type": "long"
+        },
+        {
+            "name": "clarity_version",
+            "type": [
+                "null",
+                "long"
+            ]
+        },
+        {
+            "name": "source_code",
+            "type": "string"
+        },
+        {
+            "name": "abi",
+            "type": "string"
+        }
+    ]
+}

--- a/schemas/stack_transaction.avsc
+++ b/schemas/stack_transaction.avsc
@@ -1,0 +1,358 @@
+{
+  "type": "record",
+  "name": "TransactionRecord",
+  "namespace": "com.example",
+  "fields": [
+    {
+      "name": "tx_id",
+      "type": "string"
+    },
+    {
+      "name": "nonce",
+      "type": "int"
+    },
+    {
+      "name": "fee_rate",
+      "type": "string"
+    },
+    {
+      "name": "sender_address",
+      "type": "string"
+    },
+    {
+      "name": "sponsored",
+      "type": "boolean"
+    },
+    {
+      "name": "post_condition_mode",
+      "type": "string"
+    },
+    {
+      "name": "post_conditions",
+      "type": {
+        "type": "array",
+        "items": {
+          "type": "record",
+          "name": "PostConditionsRecord",
+          "fields": [
+            {
+              "name": "type",
+              "type": "string"
+            },
+            {
+              "name": "condition_code",
+              "type": "string"
+            },
+            {
+              "name": "amount",
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            {
+              "name": "principal",
+              "type": {
+                "type": "record",
+                "name": "PrincipalRecord",
+                "fields": [
+                  {
+                    "name": "type_id",
+                    "type": "string"
+                  },
+                  {
+                    "name": "address",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  {
+                    "name": "contract_name",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "asset",
+              "type": [
+                "null",
+                {
+                  "type": "record",
+                  "name": "AssetRecord",
+                  "fields": [
+                    {
+                      "name": "asset_name",
+                      "type": "string"
+                    },
+                    {
+                      "name": "contract_address",
+                      "type": "string"
+                    },
+                    {
+                      "name": "contract_name",
+                      "type": "string"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "asset_value",
+              "type": [
+                "null",
+                {
+                  "type": "record",
+                  "name": "AssetValueRecord",
+                  "fields": [
+                    {
+                      "name": "hex",
+                      "type": "string"
+                    },
+                    {
+                      "name": "repr",
+                      "type": "string"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "anchor_mode",
+      "type": "string"
+    },
+    {
+      "name": "is_unanchored",
+      "type": "boolean"
+    },
+    {
+      "name": "block_hash",
+      "type": "string"
+    },
+    {
+      "name": "parent_block_hash",
+      "type": "string"
+    },
+    {
+      "name": "block_height",
+      "type": "long"
+    },
+    {
+      "name": "burn_block_time",
+      "type": "long"
+    },
+    {
+      "name": "burn_block_time_iso",
+      "type": "string"
+    },
+    {
+      "name": "parent_burn_block_time",
+      "type": "long"
+    },
+    {
+      "name": "parent_burn_block_time_iso",
+      "type": "string"
+    },
+    {
+      "name": "canonical",
+      "type": "boolean"
+    },
+    {
+      "name": "tx_index",
+      "type": "int"
+    },
+    {
+      "name": "tx_status",
+      "type": "string"
+    },
+    {
+      "name": "tx_result",
+      "type": {
+        "type": "record",
+        "name": "TxResult",
+        "fields": [
+          {
+            "name": "hex",
+            "type": "string"
+          },
+          {
+            "name": "repr",
+            "type": "string"
+          }
+        ]
+      }
+    },
+    {
+      "name": "microblock_hash",
+      "type": "string"
+    },
+    {
+      "name": "microblock_sequence",
+      "type": "int"
+    },
+    {
+      "name": "microblock_canonical",
+      "type": "boolean"
+    },
+    {
+      "name": "event_count",
+      "type": "int"
+    },
+    {
+      "name": "events",
+      "type": {
+        "type": "array",
+        "items": {
+          "type": "record",
+          "name": "EventRecord",
+          "fields": [
+            {
+              "name": "event_index",
+              "type": "int"
+            },
+            {
+              "name": "event_type",
+              "type": "string"
+            },
+            {
+              "name": "tx_id",
+              "type": "string"
+            },
+            {
+              "name": "asset",
+              "type": {
+                "type": "record",
+                "name": "Asset",
+                "fields": [
+                  {
+                    "name": "asset_event_type",
+                    "type": "string"
+                  },
+                  {
+                    "name": "sender",
+                    "type": "string"
+                  },
+                  {
+                    "name": "recipient",
+                    "type": "string"
+                  },
+                  {
+                    "name": "amount",
+                    "type": "string"
+                  },
+                  {
+                    "name": "memo",
+                    "type": "string"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "execution_cost_read_count",
+      "type": "int"
+    },
+    {
+      "name": "execution_cost_read_length",
+      "type": "int"
+    },
+    {
+      "name": "execution_cost_runtime",
+      "type": "int"
+    },
+    {
+      "name": "execution_cost_write_count",
+      "type": "int"
+    },
+    {
+      "name": "execution_cost_write_length",
+      "type": "int"
+    },
+    {
+      "name": "tx_type",
+      "type": "string"
+    },
+    {
+      "name": "token_transfer",
+      "type": [
+        "null",
+        {
+          "type": "record",
+          "name": "TokenTransferRecord",
+          "fields": [
+            {
+              "name": "recipient_address",
+              "type": "string"
+            },
+            {
+              "name": "amount",
+              "type": "string"
+            },
+            {
+              "name": "memo",
+              "type": "string"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "coinbase_payload",
+      "type": [
+        "null",
+        {
+          "type": "record",
+          "name": "CoinbasePayloadRecord",
+          "fields": [
+            {
+              "name": "data",
+              "type": "string"
+            },
+            {
+              "name": "alt_recipient",
+              "type": "string"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "smart_contract",
+      "type": [
+        "null",
+        {
+          "type": "record",
+          "name": "SmartContractRecord",
+          "fields": [
+            {
+              "name": "clarity_version",
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            {
+              "name": "contract_id",
+              "type": "string"
+            },
+            {
+              "name": "source_code",
+              "type": "string"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/schemas/stack_transaction.avsc
+++ b/schemas/stack_transaction.avsc
@@ -9,7 +9,7 @@
     },
     {
       "name": "nonce",
-      "type": "int"
+      "type": "long"
     },
     {
       "name": "fee_rate",
@@ -167,7 +167,7 @@
     },
     {
       "name": "tx_index",
-      "type": "int"
+      "type": "long"
     },
     {
       "name": "tx_status",
@@ -196,7 +196,7 @@
     },
     {
       "name": "microblock_sequence",
-      "type": "int"
+      "type": "long"
     },
     {
       "name": "microblock_canonical",
@@ -204,7 +204,7 @@
     },
     {
       "name": "event_count",
-      "type": "int"
+      "type": "long"
     },
     {
       "name": "events",
@@ -216,7 +216,7 @@
           "fields": [
             {
               "name": "event_index",
-              "type": "int"
+              "type": "long"
             },
             {
               "name": "event_type",
@@ -261,23 +261,23 @@
     },
     {
       "name": "execution_cost_read_count",
-      "type": "int"
+      "type": "long"
     },
     {
       "name": "execution_cost_read_length",
-      "type": "int"
+      "type": "long"
     },
     {
       "name": "execution_cost_runtime",
-      "type": "int"
+      "type": "long"
     },
     {
       "name": "execution_cost_write_count",
-      "type": "int"
+      "type": "long"
     },
     {
       "name": "execution_cost_write_length",
-      "type": "int"
+      "type": "long"
     },
     {
       "name": "tx_type",


### PR DESCRIPTION
### Summary 
Added schema for stack's block and transaction

The block schema can be [found here ](https://docs.hiro.so/api/get-block-by-height) [example](https://api.mainnet.hiro.so/extended/v1/block/by_height/501)

For transaction need to check some transactions and the `Transaction` type in `@stacks/stacks-blockchain-api-types` to get the type of `post_conditions`
[tx 1 - token transfer example](https://api.mainnet.hiro.so/extended/v1/tx/0xa17391ac49b0fc61445f75e5495a3ef9167ce6249542cbe4d3e33db3850ebc93)
[tx 2 - source code example](https://api.mainnet.hiro.so/extended/v1/tx/0xd8a9a4528ae833e1894eee676af8d218f8facbf95e166472df2c1a64219b5dfb)
[tx 3 - coinbase example](https://api.mainnet.hiro.so/extended/v1/tx/0x73dd0f3c2915dd25936c5c52598498c1d4089fe6f043bd414346a0895dc0fe87)